### PR TITLE
Added DSL for supporting parametrized queries/mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.1.1 (Next)
 
 * Your contribution here.
+* [#33](https://github.com/ashkan18/graphlient/pull/33): Added dsl for supporting parametrized queries/mutations - [@ashkan18](https://github.com/ashkan18).
 
 ### 0.1.0 (10/27/2017)
 

--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ end
 ```
 Graphlient supports following Scalar types for parameterized queries by default:
 - `:id` maps to `ID`
+- `:boolean` maps to `Boolean`
+- `:float` maps to `Float`
 - `:int` maps to `Int`
 - `:string` maps to `String`
-- `:boolean` maps to `Boolean`
 
 You can use any of the above types with `!` to make it required or use them in `[]` for array parameters.
 

--- a/README.md
+++ b/README.md
@@ -144,21 +144,30 @@ With a block.
 
 ```ruby
 client.query(ids: [42]) do
-  query(:$ids => :'[Int]') do
-    invoices(ids: :$ids) do
+  query(ids: [:int]) do
+    invoices(ids: :ids) do
       id
       fee_in_cents
     end
   end
 end
 ```
+Graphlient supports following Scalar types for parameterized queries by default:
+- `:id` maps to `ID`
+- `:int` maps to `Int`
+- `:string` maps to `String`
+- `:boolean` maps to `Boolean`
+
+You can use any of the above types with `!` to make it required or use them in `[]` for array parameters.
+
+For any other costume types, graphlient will simply use `to_s` of the symbol provided for the type, so `query(ids: [:InvoiceType!])` will result in `query($ids: [InvoiceType!])`.
 
 The following mutation accepts a custom type that requires `fee_in_cents`.
 
 ```ruby
 client.query(input: { fee_in_cents: 12_345 }) do
-  mutation(:$input => :createInvoiceInput!) do
-    createInvoice(input: :$input) do
+  mutation(input: :createInvoiceInput!) do
+    createInvoice(input: :input) do
       id
       fee_in_cents
     end
@@ -174,8 +183,8 @@ You can `parse` and `execute` queries separately with optional variables. This i
 ```ruby
 # parse a query, returns a GraphQL::Client::OperationDefinition
 query = client.parse do
-  query(:$ids => :'[Int]') do
-    invoices(ids: :$ids) do
+  query(ids: [:int]) do
+    invoices(ids: :ids) do
       id
       fee_in_cents
     end
@@ -214,8 +223,8 @@ Define a query.
 ```ruby
 module SWAPI
   InvoiceQuery = Client.parse do
-    query(:$id => :Int) do
-      invoice(id: :$id) do
+    query(id: :int) do
+      invoice(id: :id) do
         id
         fee_in_cents
       end

--- a/lib/graphlient/query.rb
+++ b/lib/graphlient/query.rb
@@ -1,15 +1,32 @@
 module Graphlient
   class Query
+    SCALAR_TYPES = {
+      int: 'Int',
+      float: 'Float',
+      string: 'String',
+      boolean: 'Boolean'
+    }.freeze
+
+    ROOT_NODES = %w(query mutation subscription).freeze
+
     attr_accessor :query_str
 
     def initialize(&block)
       @indents = 0
       @query_str = ''
+      @variables = []
       instance_eval(&block)
     end
 
     def method_missing(m, *args, &block)
-      append(m, args, &block)
+      append_node(m, args, &block)
+    end
+
+    ROOT_NODES.each do |root_node|
+      define_method(root_node) do |*args, &block|
+        @variables = args.first unless args.empty?
+        append_node(root_node, args, arg_processor: ->(k, v) { "$#{k}: #{variable_string(v)}" }, &block)
+      end
     end
 
     def respond_to_missing?(m, include_private = false)
@@ -22,11 +39,12 @@ module Graphlient
 
     private
 
-    def append(query_field, args, &block)
+    def append_node(node, args, arg_processor: nil, &block)
       # add field
-      @query_str << "\n#{indent}#{query_field}"
+      @query_str << "\n#{indent}#{node}"
       # add filter
-      @query_str << "(#{get_args_str(args)})" if find_hash_arg(args)
+      hash_arguments = hash_arg(args)
+      @query_str << "(#{args_str(hash_arguments, arg_processor: arg_processor)})" if hash_arguments
 
       if block_given?
         @indents += 1
@@ -43,28 +61,46 @@ module Graphlient
       '  ' * @indents
     end
 
-    def get_args_str(args)
-      hash_args_str(find_hash_arg(args))
-    end
-
-    def find_hash_arg(args)
+    def hash_arg(args)
       args.detect { |arg| arg.is_a? Hash }
     end
 
-    def hash_args_str(hash)
-      hash.map { |k, v| "#{k}: #{get_arg_value_str(v)}" }.join(', ')
+    def args_str(hash_args, arg_processor: nil)
+      hash_args.map do |k, v|
+        arg_processor ? arg_processor.call(k, v) : argument_string(k, v)
+      end.join(', ')
     end
 
-    def get_arg_value_str(value)
+    def argument_string(k, v)
+      "#{k}: #{argument_value_string(v)}"
+    end
+
+    def variable_string(v)
+      case v
+      when :id, :id!
+        v.to_s.upcase
+      when ->(value) { SCALAR_TYPES.key?(value.to_s.delete('!').to_sym) }
+        # scalar types
+        v.to_s.camelize
+      when Array
+        "[#{variable_string(v.first)}]"
+      else
+        v.to_s
+      end
+    end
+
+    def argument_value_string(value)
       case value
       when String
         "\"#{value}\""
       when Numeric
         value.to_s
       when Array
-        "[#{value.map { |v| get_arg_value_str(v) }.join(', ')}]"
+        "[#{value.map { |v| argument_value_string(v) }.join(', ')}]"
       when Hash
-        "{ #{hash_args_str(value)} }"
+        "{ #{value.map { |k, v| "#{k}: #{argument_value_string(v)}" }.join(', ')} }"
+      when Symbol
+        @variables.keys.include?(value) ? "$#{value}" : value.to_s.camelize(:lower)
       else
         value
       end

--- a/spec/graphlient/client_query_spec.rb
+++ b/spec/graphlient/client_query_spec.rb
@@ -30,8 +30,8 @@ describe Graphlient::Client do
     context 'parameterized query' do
       let(:query) do
         client.parse do
-          query(:$ids => :'[Int]') do
-            invoices(ids: :$ids) do
+          query(some_ids: [:int]) do
+            invoices(ids: :some_ids) do
               id
               fee_in_cents
             end
@@ -44,7 +44,7 @@ describe Graphlient::Client do
       end
 
       it '#execute' do
-        response = client.execute(query, ids: [42])
+        response = client.execute(query, some_ids: [42])
         invoices = response.data.invoices
         expect(invoices.first.id).to eq 42
         expect(invoices.first.fee_in_cents).to eq 20_000
@@ -162,8 +162,8 @@ describe Graphlient::Client do
       it 'fails when missing input' do
         expect do
           client.query do
-            mutation('$input' => :createInvoiceInput!) do
-              createInvoice(input: :$input) do
+            mutation(input: :createInvoiceInput!) do
+              createInvoice(input: :input) do
                 id
                 fee_in_cents
               end
@@ -175,8 +175,8 @@ describe Graphlient::Client do
 
       it 'returns a response from a query' do
         response = client.query(ids: [42]) do
-          query(:$ids => :'[Int]') do
-            invoices(ids: :$ids) do
+          query(ids: [:int]) do
+            invoices(ids: :ids) do
               id
               fee_in_cents
             end
@@ -190,8 +190,8 @@ describe Graphlient::Client do
 
       it 'executes the mutation' do
         response = client.query(input: { fee_in_cents: 12_345 }) do
-          mutation(:$input => :createInvoiceInput!) do
-            createInvoice(input: :$input) do
+          mutation(input: :createInvoiceInput!) do
+            createInvoice(input: :input) do
               id
               fee_in_cents
             end
@@ -206,8 +206,8 @@ describe Graphlient::Client do
       it 'fails when mutation missing a field' do
         expect do
           client.query(input: {}) do
-            mutation(:$input => :createInvoiceInput!) do
-              createInvoice(input: :$input) do
+            mutation(input: :createInvoiceInput!) do
+              createInvoice(input: :input) do
                 id
                 fee_in_cents
               end

--- a/spec/graphlient/query_spec.rb
+++ b/spec/graphlient/query_spec.rb
@@ -51,7 +51,7 @@ describe Graphlient::Query do
         expect(query.to_s).to eq "query{\n  invoice(id: 10, threshold: 10.3, item_list: [\"str_item\", 2]){\n    line_items(name: \"new name\")\n    }\n  }"
       end
 
-      it 'returns proper query with query name' do
+      it 'returns proper query' do
         query = Graphlient::Query.new do
           query do
             invoice(id: 10) do
@@ -62,6 +62,19 @@ describe Graphlient::Query do
           end
         end
         expect(query.to_s).to eq "query{\n  invoice(id: 10){\n    line_items{\n      line_item_type\n      }\n    }\n  }"
+      end
+
+      it 'returns proper query with query variables' do
+        query = Graphlient::Query.new do
+          query(invoice_id: :int, names: [:string!]) do
+            invoice(id: :invoice_id, name: :names) do
+              line_items do
+                line_item_type
+              end
+            end
+          end
+        end
+        expect(query.to_s).to eq "query($invoice_id: Int, $names: [String!]){\n  invoice(id: $invoice_id, name: $names){\n    line_items{\n      line_item_type\n      }\n    }\n  }"
       end
     end
 

--- a/spec/graphlient/static_client_query_spec.rb
+++ b/spec/graphlient/static_client_query_spec.rb
@@ -16,8 +16,8 @@ describe Graphlient::Client do
       end
 
       Query = Client.parse do
-        query(:$ids => :'[Int]') do
-          invoices(ids: :$ids) do
+        query(some_ids: [:int]) do
+          invoices(ids: :some_ids) do
             id
             fee_in_cents
           end
@@ -30,7 +30,7 @@ describe Graphlient::Client do
     end
 
     it '#execute' do
-      response = Graphlient::Client::Spec::Client.execute(Graphlient::Client::Spec::Query, ids: [42])
+      response = Graphlient::Client::Spec::Client.execute(Graphlient::Client::Spec::Query, some_ids: [42])
       invoices = response.data.invoices
       expect(invoices.first.id).to eq 42
       expect(invoices.first.fee_in_cents).to eq 20_000


### PR DESCRIPTION
# Feature
We want to support parametrized queries/mutations with our current dsl.

fixes #23 

# Solution
We now parse arguments passed to root nodes differently. Parameters passed to `query`, `mutation` and `subscription` are considered as `variables` we store variable names and replace them with `$<parameter name>`. When parameters used in the query we also detect those and replace them with proper variable name. So following query
```ruby
query(ids: [:int!]) do
  invoices(ids: :ids) do
     id
     fee_in_cents
  end
end
```
Will result in
```graphql
query($ids: [Int!]) {
  invoices(ids: $ids) {
     id
     fee_in_cents
  }
}
```
We support basic Scalar types
- `:int`
- `:string`
- `:boolean`
- `:float`

For any other custom types we simply use `string` representation of the symbol. For example
```ruby
mutation(input: :createInvoiceInput!) {
  invoice(input: :input) {
    id
  }
}
```
Will result in
```graphql
mutation($input: createInvoiceInput!){
  invoice(input: $input) {
     id
   }
}
````