### PR TITLE
Fix NoAMethodError in FaradayServerError

### DIFF
--- a/lib/graphlient/errors/faraday_server_error.rb
+++ b/lib/graphlient/errors/faraday_server_error.rb
@@ -4,8 +4,8 @@ module Graphlient
       def initialize(inner_exception)
         super(inner_exception.message, inner_exception)
         @inner_exception = inner_exception
-        @response = inner_exception.response[:body]
-        @status_code = inner_exception.response[:status]
+        @response = inner_exception.response.try(:[],:body)
+        @status_code = inner_exception.response.try(:[],:status)
       end
     end
   end


### PR DESCRIPTION
Problem:
Error when Faraday::ClientError.new(nil)

Solution
added try to the response hash on FaradayServerError
