### PR TITLE
Remove safe navigation to support < ruby v2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ Style/FrozenStringLiteralComment:
 Style/Documentation:
   Enabled: false
 
+Style/SafeNavigation:
+  Enabled: false
+
 Metrics/LineLength:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.3.4 (Next)
 
+* [#56](https://github.com/ashkan18/graphlient/pull/56): Remove safe navigation usage to retain support for Ruby 2.2 - [@avinoth](https://github.com/avinoth).
 * Your contribution here.
 
 ### 0.3.2 (09/23/2018)

--- a/lib/graphlient/adapters/http/http_adapter.rb
+++ b/lib/graphlient/adapters/http/http_adapter.rb
@@ -9,7 +9,7 @@ module Graphlient
 
           request['Accept'] = 'application/json'
           request['Content-Type'] = 'application/json'
-          headers.to_a.each { |name, value| request[name] = value }
+          headers && headers.each { |name, value| request[name] = value }
 
           body = {}
           body['query'] = document.to_query_string

--- a/lib/graphlient/adapters/http/http_adapter.rb
+++ b/lib/graphlient/adapters/http/http_adapter.rb
@@ -9,7 +9,7 @@ module Graphlient
 
           request['Accept'] = 'application/json'
           request['Content-Type'] = 'application/json'
-          headers&.each { |name, value| request[name] = value }
+          headers.to_a.each { |name, value| request[name] = value }
 
           body = {}
           body['query'] = document.to_query_string

--- a/lib/graphlient/client.rb
+++ b/lib/graphlient/client.rb
@@ -26,7 +26,7 @@ module Graphlient
       raise Graphlient::Errors::GraphQLError, rc if rc.errors.any?
       # see https://github.com/github/graphql-client/pull/132
       # see https://github.com/exAspArk/graphql-errors/issues/2
-      raise Graphlient::Errors::ExecutionError, rc if rc.data && rc.data.errors.to_a.any?
+      raise Graphlient::Errors::ExecutionError, rc if errors_in_result?(rc)
       rc
     rescue GraphQL::Client::Error => e
       raise Graphlient::Errors::ClientError, e.message
@@ -62,6 +62,10 @@ module Graphlient
       @client ||= GraphQL::Client.new(schema: schema.graphql_schema, execute: http).tap do |client|
         client.allow_dynamic_queries = @options.key?(:allow_dynamic_queries) ? options[:allow_dynamic_queries] : true
       end
+    end
+
+    def errors_in_result?(response)
+      response.data && response.data.errors && response.data.errors.any?
     end
   end
 end

--- a/lib/graphlient/client.rb
+++ b/lib/graphlient/client.rb
@@ -26,7 +26,7 @@ module Graphlient
       raise Graphlient::Errors::GraphQLError, rc if rc.errors.any?
       # see https://github.com/github/graphql-client/pull/132
       # see https://github.com/exAspArk/graphql-errors/issues/2
-      raise Graphlient::Errors::ExecutionError, rc if rc.data&.errors && rc.data.errors.any?
+      raise Graphlient::Errors::ExecutionError, rc if rc.data && rc.data.errors.to_a.any?
       rc
     rescue GraphQL::Client::Error => e
       raise Graphlient::Errors::ClientError, e.message


### PR DESCRIPTION
Safe navigation was introduced only from v2.3 whereas the older version support was needed in one of our case and the safe navigation was the only one that's preventing the lib to be backward compatible.  

Have used `.to_a` instead of `&&` to reduce cyclomatic complexity.

Feel free to close the PR if <2.3 isn't encouraged for the lib.