### PR TITLE
Remove unused typo, follow up on #62

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### 0.3.5 (Next)
-
-* [#62](https://github.com/ashkan18/graphlient/pull/62): Fix typo preventing access to response object on error - [@jmondo](https://github.com/jmondo).
 * Your contribution here.
+
+* [#63](https://github.com/ashkan18/graphlient/pull/63): Remove unused method for attribute with typo - [@ashkan18](https://github.com/ashkan18).
+* [#62](https://github.com/ashkan18/graphlient/pull/62): Fix typo preventing access to response object on error - [@jmondo](https://github.com/jmondo).
 
 ### 0.3.4 (01/31/2019)
 

--- a/lib/graphlient/errors/graphql_error.rb
+++ b/lib/graphlient/errors/graphql_error.rb
@@ -18,12 +18,6 @@ module Graphlient
         end.join("\n")
       end
 
-      def responsee
-        warn "The `#responsee' method is deprecated since it has a typo. Please use the `#response' method instead."
-
-        @responsee
-      end
-
       private
 
       def create_details(details)


### PR DESCRIPTION
Addressing https://github.com/ashkan18/graphlient/commit/3460b5e4e136cfa26271cc95383da49d9d91cf92#r34403479, removed unused method which would always return `nil`