### PR TITLE
Lock activesupport version to < 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ gemspec
 
 gem 'rake'
 
+group :development, :test do
+  gem 'activesupport', '< 6'
+end
+
 group :development do
   gem 'byebug', platform: :ruby
   gem 'danger-changelog', '~> 0.2.1'


### PR DESCRIPTION
Since graphql-client gem requires activesupport, and the latest version of activesupport requires zeitwerk (~> 2.2) which requires ruby to be >= 2.4.4, locking activesupport version to < 6 so that Travis will pass.