### PR TITLE
Fix faraday use / adapter error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-### 0.3.8 (Next)
+### 0.4.0 (Next)
 * [#72](https://github.com/ashkan18/graphlient/pull/72): Add http_options - [@neroleung](https://github.com/neroleung).
 * [#71](https://github.com/ashkan18/graphlient/issues/70): Add `Graphlient::Errors::TimeoutError` - [@BenDrozdoff](https://github.com/BenDrozdoff).
+* [#75](https://github.com/ashkan18/graphlient/pull/75): Support Faraday 1.x - [@jfhinchcliffe](https://github.com/jfhinchcliffe).
 * Your contribution here.
 
 ### 0.3.7 (14/11/2019)

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ describe App do
     Graphlient::Client.new('http://test-graphql.biz/graphql') do |client|
       client.http do |h|
         h.connection do |c|
-          c.use Faraday::Adapter::Rack, app
+          c.adapter Faraday::Adapter::Rack, app
         end
       end
     end

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,11 +1,16 @@
 Upgrading Graphlient
 ===========================
 
-### Upgrading to >= 0.3.8
+### Upgrading to >= 0.4.0
 
 #### Requires Faraday >= 1.0
 
 See [#75](https://github.com/ashkan18/graphlient/pull/75).
+
+#### Changes in error handling of connection refused error
+
+When the GraphQL request was failing, we were receiving a `Faraday::ServerError`. After 0.4.0, Graphlient
+will return `Graphlient::Errors::FaradayServerError` instead.
 
 ### Upgrading to >= 0.3.7
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,12 @@
 Upgrading Graphlient
 ===========================
 
+### Upgrading to >= 0.3.8
+
+#### Requires Faraday >= 1.0
+
+See [#75](https://github.com/ashkan18/graphlient/pull/75).
+
 ### Upgrading to >= 0.3.7
 
 #### Changes in error handling of connection refused error

--- a/graphlient.gemspec
+++ b/graphlient.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/ashkan18/graphlient'
   s.licenses = ['MIT']
   s.summary = 'A friendlier Ruby client for consuming GraphQL-based APIs.'
-  s.add_dependency 'faraday'
+  s.add_dependency 'faraday', '>= 1.0'
   s.add_dependency 'faraday_middleware'
   s.add_dependency 'graphql-client'
 end

--- a/lib/graphlient/adapters/http/faraday_adapter.rb
+++ b/lib/graphlient/adapters/http/faraday_adapter.rb
@@ -21,6 +21,8 @@ module Graphlient
           raise Graphlient::Errors::TimeoutError, e
         rescue Faraday::ClientError => e
           raise Graphlient::Errors::FaradayServerError, e
+        rescue Faraday::ServerError => e
+          raise Graphlient::Errors::FaradayServerError, e
         end
 
         def connection

--- a/lib/graphlient/adapters/http/faraday_adapter.rb
+++ b/lib/graphlient/adapters/http/faraday_adapter.rb
@@ -34,7 +34,7 @@ module Graphlient
             if block_given?
               yield c
             else
-              c.use Faraday::Adapter::NetHttp
+              c.adapter Faraday::Adapter::NetHttp
             end
           end
         end

--- a/lib/graphlient/version.rb
+++ b/lib/graphlient/version.rb
@@ -1,3 +1,3 @@
 module Graphlient
-  VERSION = '0.3.7'.freeze
+  VERSION = '0.3.8'.freeze
 end

--- a/lib/graphlient/version.rb
+++ b/lib/graphlient/version.rb
@@ -1,3 +1,3 @@
 module Graphlient
-  VERSION = '0.3.8'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/spec/graphlient/adapters/http/faraday_adapter_spec.rb
+++ b/spec/graphlient/adapters/http/faraday_adapter_spec.rb
@@ -8,19 +8,19 @@ describe Graphlient::Adapters::HTTP::FaradayAdapter do
       Graphlient::Client.new('http://example.com/graphql') do |client|
         client.http do |h|
           h.connection do |c|
-            c.use Faraday::Adapter::Rack, app
+            c.adapter Faraday::Adapter::Rack, app
           end
         end
       end
     end
 
     it 'inserts a middleware into the connection' do
+      expect(client.http.connection.adapter).to eq Faraday::Adapter::Rack
       expect(client.http.connection.builder.handlers).to eq(
         [
           Faraday::Response::RaiseError,
           FaradayMiddleware::EncodeJson,
-          FaradayMiddleware::ParseJson,
-          Faraday::Adapter::Rack
+          FaradayMiddleware::ParseJson
         ]
       )
     end

--- a/spec/graphlient/client_schema_spec.rb
+++ b/spec/graphlient/client_schema_spec.rb
@@ -19,7 +19,7 @@ describe Graphlient::Client do
       it 'fails with an exception' do
         expect do
           client.schema
-        end.to raise_error Graphlient::Errors::ServerError do |e|
+        end.to raise_error Graphlient::Errors::FaradayServerError do |e|
           expect(e.to_s).to eq 'the server responded with status 500'
           expect(e.status_code).to eq 500
           expect(e.response['errors'].size).to eq 1

--- a/spec/graphlient/static_client_query_spec.rb
+++ b/spec/graphlient/static_client_query_spec.rb
@@ -10,7 +10,7 @@ describe Graphlient::Client do
       ) do |client|
         client.http do |h|
           h.connection do |c|
-            c.use Faraday::Adapter::Rack, Sinatra::Application
+            c.adapter Faraday::Adapter::Rack, Sinatra::Application
           end
         end
       end

--- a/spec/support/context/dummy_client.rb
+++ b/spec/support/context/dummy_client.rb
@@ -18,7 +18,7 @@ RSpec.shared_context 'Dummy Client', shared_context: :metadata do
     Graphlient::Client.new(endpoint, headers: headers) do |client|
       client.http do |h|
         h.connection do |c|
-          c.use Faraday::Adapter::Rack, app
+          c.adapter Faraday::Adapter::Rack, app
         end
       end
     end


### PR DESCRIPTION
References this issue: https://github.com/ashkan18/graphlient/issues/73

Faraday has changed so we need to assign an adapter using `f.adapter` rather than `f.use`.

As part of this PR, a few tests broke with nested errors etc. I've fixed them / got them all green, however I'm not too familiar with inner exceptions so it's worth a look from someone who knows a bit more than me :)

Will do changelog etc. shortly.

edit

ugh, I'm using Ruby 2.6, and this is 2.3. Having trouble getting Bundler to work with 2.3 :\