### PR TITLE
Allow use of big int in rails notation

### DIFF
--- a/lib/graphlient/query.rb
+++ b/lib/graphlient/query.rb
@@ -2,6 +2,7 @@ module Graphlient
   class Query
     SCALAR_TYPES = {
       int: 'Int',
+      big_int: 'BigInt',
       float: 'Float',
       string: 'String',
       boolean: 'Boolean'


### PR DESCRIPTION
Currently not possible to use `BigInt` in rails notation.