### PR TITLE
fix: raise `ExecutionError` with partial error response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.6.0 (Next)
 * Your contribution here.
 
+* [#87](https://github.com/ashkan18/graphlient/pull/87): Raised `ExecutionError` with partial error response - [@QQism](https://github.com/QQism).
 * [#90](https://github.com/ashkan18/graphlient/pull/90): Added support for Ruby 3.1 - [@QQism](https://github.com/QQism).
 * [#90](https://github.com/ashkan18/graphlient/pull/90): Dropped support for Ruby 2.5 - [@QQism](https://github.com/QQism).
 * [#91](https://github.com/ashkan18/graphlient/pull/91): Update GHA for `danger` with right permissions - [@QQism](https://github.com/QQism).

--- a/lib/graphlient/client.rb
+++ b/lib/graphlient/client.rb
@@ -67,7 +67,7 @@ module Graphlient
     end
 
     def errors_in_result?(response)
-      response.data && response.data.errors && response.data.errors.any?
+      response.data && response.data.errors && response.data.errors.all.any?
     end
   end
 end

--- a/spec/graphlient/client_query_spec.rb
+++ b/spec/graphlient/client_query_spec.rb
@@ -91,6 +91,18 @@ describe Graphlient::Client do
         GRAPHQL
       end
 
+      let(:partial_success_query) do
+        <<-GRAPHQL
+          query {
+            someInvoices {
+              id
+              feeInCents
+              createdAt
+            }
+          }
+        GRAPHQL
+      end
+
       it '#execute' do
         response = client.execute(query, id: 42)
         invoice = response.data.invoice
@@ -126,6 +138,14 @@ describe Graphlient::Client do
         expect do
           client.execute(not_null_query, id: 42)
         end.to raise_error Graphlient::Errors::GraphQLError do |e|
+          expect(e.response).to be_a GraphQL::Client::Response
+        end
+      end
+
+      it 'fails with a partial error response' do
+        expect do
+          client.execute(partial_success_query)
+        end.to raise_error Graphlient::Errors::ExecutionError do |e|
           expect(e.response).to be_a GraphQL::Client::Response
         end
       end

--- a/spec/support/queries/query.rb
+++ b/spec/support/queries/query.rb
@@ -15,6 +15,10 @@ class Query < GraphQL::Schema::Object
     argument :id, Integer, required: false
   end
 
+  field :some_invoices, [InvoiceType], null: true do
+    description 'List of invoices'
+  end
+
   def invoice(id: nil)
     return nil if id.nil?
     OpenStruct.new(
@@ -31,5 +35,13 @@ class Query < GraphQL::Schema::Object
     execution_errors.add(GraphQL::ExecutionError.new('Execution Error'))
 
     invoice(id: id)
+  end
+
+  def some_invoices
+    [
+      OpenStruct.new(id: 0, fee_in_cents: 20_000),
+      OpenStruct.new(id: 1, fee_in_cents: 20_000),
+      OpenStruct.new(id: 2, fee_in_cents: 20_000)
+    ]
   end
 end

--- a/spec/support/types/invoice_type.rb
+++ b/spec/support/types/invoice_type.rb
@@ -4,4 +4,10 @@ class InvoiceType < GraphQL::Schema::Object
 
   field :id, ID, null: false
   field :fee_in_cents, Integer, null: true
+  field :created_at, String, null: true, extras: [:execution_errors]
+
+  def created_at(execution_errors:)
+    execution_errors.add(GraphQL::ExecutionError.new('This is a partial error'))
+    Time.now.iso8601
+  end
 end


### PR DESCRIPTION
When the GraphQL response has nested errors, `graphlient` does not raise
the `ExcutionError` which is not expected. This commit will check all
errors (including nested one) by using `errors.all` and make sure the
exception is raised.

Some considerations:
- Should we use the `Graphlient::Errors::ExecutionError` for partial
  success response or create a new type of exception to maintain
  backward compatibility? I tend to think having one type of exception
  could make things simpler for usage.
- Should `graphlient` ignore nested errors and not raise exception?
  Apparently, the whole point of this commit is about it. I'm working on
  a sensitive GraphQL client app, and any type of errors should be well
  aware to proceed to the appropriate next step.

References:
- https://github.com/github/graphql-client/pull/132#issuecomment-386111906