### PR TITLE
chore: drop support for Ruby 2.5 & add Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: push
+on: [push, pull_request]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         ruby-version:
           - 2.7.2
           - 3.0.0
+          - 3.1.2
           - ruby-head
           - jruby-9.1.17
           - jruby-head

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ contains(fromJSON('["2.5.0", "ruby-head", "jruby-9.1", "jruby-head"]'), matrix.ruby-version) }}
+    continue-on-error: ${{ contains(fromJSON('["ruby-head", "jruby-9.1", "jruby-head"]'), matrix.ruby-version) }}
     strategy:
       matrix:
         ruby-version:
-          - 2.5.0
           - 2.7.2
           - 3.0.0
           - ruby-head

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,22 +8,22 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ contains(fromJSON('["ruby-head", "jruby-9.1", "jruby-head"]'), matrix.ruby-version) }}
     strategy:
       matrix:
-        ruby-version:
-          - 2.7.2
-          - 3.0.0
-          - 3.1.2
-          - ruby-head
-          - jruby-9.1.17
-          - jruby-head
+        entry:
+          - { ruby: 2.7.2 }
+          - { ruby: 3.0.0 }
+          - { ruby: 3.1.2 }
+          - { ruby: "ruby-head", ignore: true }
+          - { ruby: "jruby-9.1.17", ignore: true }
+          - { ruby: "jruby-head", ignore: true }
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby-version }}
+        ruby-version: ${{ matrix.entry.ruby }}
         bundler-cache: true
     - name: Run tests
+      continue-on-error: ${{ matrix.entry.ignore || false }}
       run: bundle exec rspec spec/

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,6 @@
 name: Rubocop
 
-on: push
+on: [push, pull_request]
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.6.0 (Next)
 * Your contribution here.
 
+* [#90](https://github.com/ashkan18/graphlient/pull/90): Added support for Ruby 3.1 - [@QQism](https://github.com/QQism).
 * [#90](https://github.com/ashkan18/graphlient/pull/90): Dropped support for Ruby 2.5 - [@QQism](https://github.com/QQism).
 * [#91](https://github.com/ashkan18/graphlient/pull/91): Update GHA for `danger` with right permissions - [@QQism](https://github.com/QQism).
 * [#89](https://github.com/ashkan18/graphlient/pull/89): Replace Travis CI with Github Actions - [@QQism](https://github.com/QQism).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.6.0 (Next)
 * Your contribution here.
 
+* [#90](https://github.com/ashkan18/graphlient/pull/90): Dropped support for Ruby 2.5 - [@QQism](https://github.com/QQism).
 * [#91](https://github.com/ashkan18/graphlient/pull/91): Update GHA for `danger` with right permissions - [@QQism](https://github.com/QQism).
 * [#89](https://github.com/ashkan18/graphlient/pull/89): Replace Travis CI with Github Actions - [@QQism](https://github.com/QQism).
 


### PR DESCRIPTION
This PR will make few changes as below
- Drop support for Ruby 2.5 as it reached EOL more than a year ago and specs running against
it are failing
- Add support for Ruby 3.1 as it is the latest official Ruby version
- Switch to use GHA matrix with multiple fields for readability
- Run CI and Rubocop on pull requests



See: 
- https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-5-9-released
- https://github.com/ashkan18/graphlient/pull/89#issuecomment-1146858719