### PR TITLE
fix: update GHA for danger with right permissions

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -7,22 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.2
         bundler-cache: true
-    - uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-    - uses: MeilCli/danger-action@v5
-      with:
-        plugins_file: 'Gemfile'
-        install_path: 'vendor/bundle'
-        danger_file: 'Dangerfile'
-        danger_id: 'danger-pr'
-      env:
-        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - run: |
+        # the personal token is public, this is ok, base64 encode to avoid tripping Github
+        TOKEN=$(echo -n NWY1ZmM5MzEyMzNlYWY4OTZiOGU3MmI3MWQ3Mzk0MzgxMWE4OGVmYwo= | base64 --decode)
+        DANGER_GITHUB_API_TOKEN=$TOKEN bundle exec danger --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.6.0 (Next)
 * Your contribution here.
 
+* [#91](https://github.com/ashkan18/graphlient/pull/91): Update GHA for `danger` with right permissions - [@QQism](https://github.com/QQism).
 * [#89](https://github.com/ashkan18/graphlient/pull/89): Replace Travis CI with Github Actions - [@QQism](https://github.com/QQism).
 
 ### 0.5.0 (12/28/2020)


### PR DESCRIPTION
By default, `GITHUB_TOKEN` from a fork repository doesn't have write
permission to the current pull request, so we have to use a personal
token.

See: https://github.com/ashkan18/graphlient/pull/89#discussion_r889719956