### PR TITLE
Enable fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-### 0.6.1 (Next)
+### 0.7.0 (Next)
 
-* Your contribution here.
+* [#94](https://github.com/ashkan18/graphlient/pull/94): Enabled fragments via constant convention usage (i.e. `___Human__Fragment`) to expose the parsing of the actual fragment constant to the back-end gem ([`GraphQL Client`](https://github.com/github/graphql-client#defining-queries) feature.
 
 ### 0.6.0 (2022/06/11)
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development, :test do
 end
 
 group :development do
-  gem 'byebug', platform: :ruby
+  gem 'byebug', platform: %i[ruby x64_mingw]
   gem 'danger-changelog', '~> 0.2.1'
   gem 'rubocop', '0.56.0'
 end

--- a/lib/graphlient/version.rb
+++ b/lib/graphlient/version.rb
@@ -1,3 +1,3 @@
 module Graphlient
-  VERSION = '0.6.1'.freeze
+  VERSION = '0.7.0'.freeze
 end

--- a/spec/graphlient/adapters/http/faraday_adapter_spec.rb
+++ b/spec/graphlient/adapters/http/faraday_adapter_spec.rb
@@ -89,8 +89,7 @@ describe Graphlient::Adapters::HTTP::FaradayAdapter do
     end
 
     specify do
-      expected_error_message = "Connection refused - #{error_message}"
-
+      expected_error_message = "No connection could be made because the target machine actively refused it. - #{error_message}"
       expect { client.schema }.to raise_error(Graphlient::Errors::ConnectionFailedError, expected_error_message)
     end
   end

--- a/spec/graphlient/adapters/http/faraday_adapter_spec.rb
+++ b/spec/graphlient/adapters/http/faraday_adapter_spec.rb
@@ -90,7 +90,7 @@ describe Graphlient::Adapters::HTTP::FaradayAdapter do
     end
 
     specify do
-      expected_error_message = "No connection could be made because the target machine actively refused it. - #{error_message}"
+      expected_error_message = "Connection refused - #{error_message}"
       expect { client.schema }.to raise_error(Graphlient::Errors::ConnectionFailedError, expected_error_message)
     end
   end


### PR DESCRIPTION
@dblock  I have added some logic to resolve constants defined in a different context, provided that the full namespace path is included on `Graphlient::Query::#parse`, although `stub_const` doesn't seem to offer a way to mock the scenario.

```ruby
module Test
  module Foo
    module Bar
      Fragment = "client.parse ..."
    end
  end
end

module Test
  module Foo
    module Baz
      # use of ___Bar__Fragment
      puts Bar::Fragment
    end
  end
end
```

In the example above, a graphlient.parse in `Baz` referring to `___Bar__Fragment` would fail to resolve. And for this reason, I have added `evaluate` (capture the context) and `resolve_fragment_constant` (constant resolution + type validation).
  * I am using `Graphlient::Errors:Error` for the type validation, but you may see this requires its own error type. so I have not added `spec` to `raise`.

