### PR TITLE
Pass in initialized schema as an option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### (Next)
 * Your contribution here.
+* [#107](https://github.com/ashkan18/graphlient/pull/107): Pass in initialized schema as an option - [@kbaum](https://github.com/kbaum).
 * [#106](https://github.com/ashkan18/graphlient/pull/106): Add 3.2 to the list of ruby ci versions - [@igor-drozdov](https://github.com/igor-drozdov).
 * [#102](https://github.com/ashkan18/graphlient/pull/102): Update ci to test latest jruby - [@ashkan18](https://github.com/ashkan18).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A friendlier Ruby client for consuming GraphQL-based APIs. Built on top of your 
 
 - [Installation](#installation)
 - [Usage](#usage)
-  - [Schema storing and loading on disk](#schema-storing-and-loading-on-disk)
+  - [Schema Storing and Loading on Disk](#schema-storing-and-loading-on-disk)
+  - [Preloading Schema Once](#preloading-schema-once)
   - [Error Handling](#error-handling)
   - [Executing Parameterized Queries and Mutations](#executing-parameterized-queries-and-mutations)
   - [Parse and Execute Queries Separately](#parse-and-execute-queries-separately)
@@ -138,6 +139,30 @@ To reduce requests to graphql API you can cache schema:
 ```ruby
 client = Client.new(url, schema_path: 'config/your_graphql_schema.json')
 client.schema.dump! # you only need to call this when graphql schema changes
+```
+
+### Preloading Schema Once
+
+Even if caching the schema on disk, instantiating `Graphlient::Client` often can be both time and memory intensive due to loading the schema for each instance. This is especially true if the schema is a large file. To get around these performance issues, instantiate your schema once and pass it in as a configuration option.
+
+One time in an initializer
+
+```ruby
+schema = Graphlient::Schema.new(
+  'https://graphql.foo.com/graphql', 'lib/graphql_schema_foo.json'
+)
+```
+
+Pass in each time you initialize a client
+
+```
+client = Graphlient::Client.new(
+  'https://graphql.foo.com/graphql',
+  schema: schema,
+  headers: {
+    'Authorization' => 'Bearer 123',
+  }
+)
 ```
 
 ### Error Handling

--- a/lib/graphlient/client.rb
+++ b/lib/graphlient/client.rb
@@ -2,9 +2,12 @@ module Graphlient
   class Client
     attr_accessor :uri, :options
 
+    class InvalidConfigurationError < StandardError; end
+
     def initialize(url, options = {}, &_block)
       @url = url
       @options = options.dup
+      raise_error_if_invalid_configuration!
       yield self if block_given?
     end
 
@@ -51,10 +54,14 @@ module Graphlient
     end
 
     def schema
-      @schema ||= Graphlient::Schema.new(http, schema_path)
+      @schema ||= options[:schema] || Graphlient::Schema.new(http, schema_path)
     end
 
     private
+
+    def raise_error_if_invalid_configuration!
+      raise InvalidConfigurationError, 'schema_path and schema cannot both be provided' if options.key?(:schema_path) && options.key?(:schema)
+    end
 
     def schema_path
       return options[:schema_path].to_s if options[:schema_path]

--- a/spec/graphlient/client_schema_spec.rb
+++ b/spec/graphlient/client_schema_spec.rb
@@ -51,5 +51,25 @@ describe Graphlient::Client do
         expect(client.schema.path).to eq 'config/schema.json'
       end
     end
+
+    context 'when preloaded schema is provided' do
+      let(:schema) { Graphlient::Schema.new(url, 'spec/support/fixtures/invoice_api.json') }
+      let(:client) { described_class.new(url, schema: schema) }
+
+      it 'returns the passed in schema' do
+        expect(client.schema).not_to be_nil
+        expect(client.schema).to eq(schema)
+      end
+    end
+
+    context 'when and a schema and a schema path are provided' do
+      let(:schema) { Graphlient::Schema.new(url, 'spec/support/fixtures/invoice_api.json') }
+      let(:client) { described_class.new(url, schema: schema, schema_path: 'spec/support/fixtures/invoice_api.json') }
+
+      it 'raises an invalid configuration error' do
+        expect { client }.to raise_error(Graphlient::Client::InvalidConfigurationError,
+                                         /schema_path and schema cannot both be provided/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Not sure if this is a problem others have run into or if there is a better solution. We are using Graphlient within sidekiq and since it is a multithreaded process, we are creating an instance of `Graphlient::Client` during each job execution. Even though we are caching our schema on disk, our schema.json is large and there is significant time and memory spent loading the schema from disk. My thought is that we might be able to instead load one schema in a rails initializer and share it among all threads. Thus far it has seemed to work in a multithreaded sidekiq instance:

#### initializer code
```ruby
$graphlient_schema = Graphlient::Schema.new('https://graphql.foo.com/graphql', 'lib/graphql_schema_foo.json')
```

#### Initialize graphlient client
```ruby
Graphlient::Client.new(
  $graphlient_schema.http,
  schema_path: $graphlient_schema.path,
  schema: $graphlient_schema,
  headers: {
    'content-type' => 'application/json',
    'Authorization' => 'Bearer 123',
  }
)
```

Let me know what you think. Is it fully theadsafe to share a `Graphlient::Schema` like this?