### PR TITLE
Ensure correct Faraday JSON parsing/response body for invalid response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### (Next)
 * Your contribution here.
+* [#110](https://github.com/ashkan18/graphlient/pull/110): Ensure correct Faraday JSON response body parsing with invalid response header - [@taylorthurlow](https://github.com/taylorthurlow).
 * [#107](https://github.com/ashkan18/graphlient/pull/107): Pass in initialized schema as an option - [@kbaum](https://github.com/kbaum).
 * [#106](https://github.com/ashkan18/graphlient/pull/106): Add 3.2 to the list of ruby ci versions - [@igor-drozdov](https://github.com/igor-drozdov).
 * [#102](https://github.com/ashkan18/graphlient/pull/102): Update ci to test latest jruby - [@ashkan18](https://github.com/ashkan18).


### PR DESCRIPTION
See my investigation here:
https://github.com/ashkan18/graphlient/issues/100#issuecomment-1877886369

In the Faraday 1 to Faraday 2 process, the JSON response middleware was rewritten from scratch, which caused a change in how permissive the middleware was to response Content-Type headers which did not properly indicate a JSON response.

In Faraday 1.x, the JSON middleware would attempt a JSON parse of the body, regardless of the presence or value of a Content-Type header. This meant that Graphlient would have raised an exception (or re-raised one caught from Faraday) if the response body was not valid JSON.

In Faraday 2.x, the new JSON middleware will only attempt to parse the response body if it determines that the Content-Type response header indicates a JSON body. By default it uses a regex on the header value (`/\bjson$/` at the time of writing). Crucially, if the header is missing, or does not match the regex, instead of raising an exception, `Faraday::Response#body` returns a String, rather than the previously-assumed Hash or Array.

This change restores the parsing logic which is tolerant to incorrect or missing Content-Type header values. Response bodies which are not valid JSON will raise an exception. Any unforeseen situation where `#body` returns a type that is not String, Hash, or Array, will raise a separate exception detailing that this is unexpected behavior and a bug should be filed.

Resolves #100

---

I can't say that I have actually replicated any graphlient-on-Faraday-1.x functionality here, as far as what exceptions are raised on failed JSON parsing, but at the very least, the production application I am using this library in is now functioning as it did before the transition.

I also added new specs.