### PR TITLE
Fix dynamic headers for Net::HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### (Next)
 * Your contribution here.
+* [#120](https://github.com/ashkan18/graphlient/pull/120): Support changing headers between requests for all HTTP adapters - [@Guflly](https://github.com/Guflly).
 
 ### 0.9.0 (2026/08/03)
 * [#118](https://github.com/ashkan18/graphlient/pull/118): Correct `TimeoutError` inheritance and rescue documentation - [@oiahoon](https://github.com/oiahoon).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ client = Graphlient::Client.new('https://test-graphql.biz/graphql',
 | read_timeout  | nil     | seconds |
 | write_timeout | nil     | seconds |
 
+Headers can be changed between requests without rebuilding the client.
+
+```ruby
+client.options[:headers] = { 'Authorization' => 'Bearer 456' }
+```
+
 The schema is available automatically via `.schema`.
 
 ```ruby

--- a/lib/graphlient/adapters/http/http_adapter.rb
+++ b/lib/graphlient/adapters/http/http_adapter.rb
@@ -9,7 +9,8 @@ module Graphlient
 
           request['Accept'] = 'application/json'
           request['Content-Type'] = 'application/json'
-          headers && headers.each { |name, value| request[name] = value }
+          request_headers = (headers || {}).merge(context[:headers] || {})
+          request_headers.each { |name, value| request[name] = value }
 
           body = {}
           body['query'] = document.to_query_string

--- a/spec/graphlient/adapters/http/http_adapter_spec.rb
+++ b/spec/graphlient/adapters/http/http_adapter_spec.rb
@@ -33,6 +33,23 @@ describe Graphlient::Adapters::HTTP::HTTPAdapter do
       expect(client.http.connection.read_timeout).to eq(read_timeout)
     end
 
+    it 'uses updated client headers for the current request' do
+      request = stub_request(:post, url)
+                .with(headers: { 'Foo' => 'updated' })
+                .to_return(status: 200, body: '{"data":{}}')
+
+      client.options[:headers] = { 'Foo' => 'updated' }
+
+      client.http.execute(
+        document: double(to_query_string: 'query { viewer { id } }'),
+        operation_name: nil,
+        variables: {},
+        context: client.options
+      )
+
+      expect(request).to have_been_requested
+    end
+
     context 'when http_options contains invalid option' do
       let(:http_options) { { an_invalid_option: 'an invalid option' } }
 


### PR DESCRIPTION
Fixes #58.

This makes the Net::HTTP adapter merge headers from the current request context, matching the Faraday adapter. Headers set through client.options[:headers] now take effect on later requests.

Tests:
- 97 specs
- RuboCop on the changed Ruby files